### PR TITLE
Add verbose logging for reindexing

### DIFF
--- a/src/file_scanner.rs
+++ b/src/file_scanner.rs
@@ -22,9 +22,9 @@ impl FileScanner {
             .git_global(true) // Respect global gitignore
             .git_exclude(true) // Respect .git/info/exclude
             .filter_entry(|entry| {
-                // Exclude .probe directory to avoid indexing our own files
+                // Exclude .probe and .git directories to avoid indexing our own files and git internals
                 if let Some(name) = entry.file_name().to_str() {
-                    if name == ".probe" && entry.path().is_dir() {
+                    if (name == ".probe" || name == ".git") && entry.path().is_dir() {
                         return false;
                     }
                 }
@@ -52,9 +52,9 @@ impl FileScanner {
             .git_global(true)
             .git_exclude(true)
             .filter_entry(|entry| {
-                // Exclude .probe directory to avoid indexing our own files
+                // Exclude .probe and .git directories to avoid indexing our own files and git internals
                 if let Some(name) = entry.file_name().to_str() {
-                    if name == ".probe" && entry.path().is_dir() {
+                    if (name == ".probe" || name == ".git") && entry.path().is_dir() {
                         return false;
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,9 @@ struct Cli {
     )]
     config_path: Option<PathBuf>,
 
+    #[arg(short = 'v', long = "verbose", help = "Enable verbose logging")]
+    verbose: bool,
+
     #[arg(help = "Search query")]
     query: Option<String>,
 }
@@ -76,7 +79,7 @@ fn main() -> Result<()> {
     match cli.command {
         Some(Commands::Rebuild) => {
             let engine = SearchEngine::new(&root_dir)?;
-            engine.rebuild_index()?;
+            engine.rebuild_index(cli.verbose)?;
         }
         Some(Commands::Stats) => {
             let engine = SearchEngine::new(&root_dir)?;
@@ -133,7 +136,7 @@ fn main() -> Result<()> {
                 };
 
                 let engine = SearchEngine::new(&root_dir)?;
-                engine.ensure_index_updated()?;
+                engine.ensure_index_updated(cli.verbose)?;
                 let results = engine.search_with_reranker(
                     &query,
                     Some(cli.num_results),

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -38,11 +38,15 @@ impl IndexMetadata {
         Ok(())
     }
 
-    pub fn needs_reindex(&self, files: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    pub fn needs_reindex(&self, files: &[PathBuf], verbose: bool) -> Result<Vec<PathBuf>> {
         let mut changed_files = Vec::new();
 
         for file in files {
-            if self.file_changed(file)? {
+            let (changed, reason) = self.file_changed_with_reason(file)?;
+            if changed {
+                if verbose {
+                    println!("[VERBOSE] File needs reindexing: {} - Reason: {}", file.display(), reason);
+                }
                 changed_files.push(file.clone());
             }
         }
@@ -66,16 +70,23 @@ impl IndexMetadata {
         Ok(())
     }
 
-    fn file_changed(&self, path: &Path) -> Result<bool> {
+    fn file_changed_with_reason(&self, path: &Path) -> Result<(bool, String)> {
         let current_metadata = match fs::metadata(path) {
             Ok(meta) => meta,
-            Err(_) => return Ok(true), // File doesn't exist, consider it changed
+            Err(e) => return Ok((true, format!("File doesn't exist or can't be read: {}", e))),
         };
 
         match self.files.get(path) {
-            Some(cached_info) => Ok(cached_info.size != current_metadata.len()
-                || cached_info.modified != current_metadata.modified()?),
-            None => Ok(true), // File not in cache, needs indexing
+            Some(cached_info) => {
+                if cached_info.size != current_metadata.len() {
+                    Ok((true, format!("Size changed: {} -> {}", cached_info.size, current_metadata.len())))
+                } else if cached_info.modified != current_metadata.modified()? {
+                    Ok((true, format!("Modified time changed: {:?} -> {:?}", cached_info.modified, current_metadata.modified()?)))
+                } else {
+                    Ok((false, "No changes".to_string()))
+                }
+            }
+            None => Ok((true, "File not in metadata cache".to_string())),
         }
     }
 

--- a/tests/test_stemming_and_config.rs
+++ b/tests/test_stemming_and_config.rs
@@ -27,7 +27,7 @@ stemming:
 
     // Create search engine and rebuild index
     let engine = SearchEngine::new(temp_dir.path()).unwrap();
-    engine.rebuild_index().unwrap();
+    engine.rebuild_index(false).unwrap();
 
     // Test that singular form matches plural
     let reranker_config = RerankerConfig {
@@ -81,7 +81,7 @@ stemming:
 
     // Create search engine and rebuild index
     let engine = SearchEngine::new(temp_dir.path()).unwrap();
-    engine.rebuild_index().unwrap();
+    engine.rebuild_index(false).unwrap();
 
     // Test that singular form does NOT match plural when stemming is disabled
     let reranker_config = RerankerConfig {


### PR DESCRIPTION
Exclude `.git` directories from indexing and add a verbose flag to prevent unnecessary reindexing after a full rebuild.

---
<a href="https://cursor.com/background-agent?bcId=bc-6687e1cc-afac-4ba9-9e81-c4f775009e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6687e1cc-afac-4ba9-9e81-c4f775009e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

